### PR TITLE
encapsulate reward to rewards.py

### DIFF
--- a/datasets/bandits.py
+++ b/datasets/bandits.py
@@ -5,6 +5,7 @@ from typing import List, Dict
 
 from datasets.arms import ArmData
 from datasets.contexts import ContextAllocateData
+from datasets.rewards import RewardData
 
 
 class Bandit:
@@ -15,8 +16,8 @@ class Bandit:
         arms: Dict, 
         contexts: Dict = None
     ) -> None:
-        # Initialize reward dictionary.
-        self.reward = reward
+        # Initialize reward dictionary to a RewardData object.
+        self.reward = RewardData(reward)
 
         # Initialize default regression equation terms.
         self.terms = []

--- a/datasets/rewards.py
+++ b/datasets/rewards.py
@@ -1,0 +1,59 @@
+import numpy as np
+
+from typing import Dict
+
+
+class RewardData:
+    name: str
+    min_value: float
+    max_value: float
+    value_type: str
+    is_normalize: bool
+
+    def __init__(self, reward: Dict) -> None:
+        self.name = reward['name']
+        self.min_value = reward['min_value']
+        self.max_value = reward['max_value']
+        self.value_type = reward['value_type']
+        if 'normalize' not in reward:
+            self.is_normalize = False
+        else:
+            self.is_normalize = reward['normalize']
+
+    def get_raw_reward(self, reward: float) -> float:
+        """ Return the scaled-up reward.
+        
+        params:
+            - reward: a normalized float reward in [0, 1].
+
+        returns:
+            - raw_reward: a scaled-up float reward in [min_value, max_value] with given value_type.
+        """
+        raw_reward = reward * (self.max_value - self.min_value) + self.min_value
+
+        if self.value_type != 'CONT':
+            return np.floor(raw_reward)
+        return raw_reward
+        
+    def get_scale_reward(self, reward: float) -> float:
+        """ Return the normalized reward.
+
+        params:
+            - reward: a scaled-up float reward in [min_value, max_value] with given value_type.
+        
+        returns:
+            - normalized_reward: a normalized float reward in [0, 1].
+        """
+        normalized_reward = (reward - self.min_value) / (self.max_value - self.min_value)
+
+        return normalized_reward
+    
+    def get_reward(self, raw_reward: float) -> float:
+        """ Return the reward value given the normalization option in configs file. """
+        if self.value_type != "CONT":
+            raw_reward = np.floor(raw_reward)
+        raw_reward = np.clip(raw_reward, self.min_value, self.max_value)
+
+        if self.is_normalize and (self.min_value != 0.0 or self.max_value != 1.0):
+            return self.get_scale_reward(raw_reward)
+        return raw_reward

--- a/sample_configs.json
+++ b/sample_configs.json
@@ -62,7 +62,8 @@
         "name": "R1",
         "min_value": 1.0,
         "max_value": 5.0,
-        "value_type": "ORD"
+        "value_type": "ORD",
+        "normalize": true
     },
     "parameters": {
         "type": "TSCONTEXTUAL",


### PR DESCRIPTION
Some major changes:
---
- Encapsulate reward initialization to `datasets/rewards.py`
- Now the code supports reward normalization. To run simulations with normalized reward, you should put `'normalization'=true` in your configs file. See reward in `sample_configs.json`.