### PR TITLE
Add TS-PostDiff

### DIFF
--- a/datasets/arms.py
+++ b/datasets/arms.py
@@ -1,13 +1,15 @@
 import pandas as pd
 
-from typing import List, Dict
+from typing import List, Dict, Union
 
 
 class ArmData:
     arms: pd.DataFrame
+    action_variables: List[str]
 
     def __init__(self, actions: List[str], arms: List[Dict]) -> None:
-        columns = ["name"] + actions
+        columns = ["name", "count"] + actions + ["success", "failure"]
+        self.action_variables = actions
         self.arms = pd.DataFrame(columns=columns)
 
         init_arms = dict.fromkeys(actions, 0)
@@ -15,6 +17,30 @@ class ArmData:
         for arm in arms:
             arm_row = init_arms.copy()
             arm_row[arm["action_variable"]] = arm["value"]
-            arm_row["name"] = arm["name"]
+            arm_row = arm_row | {
+                "name": arm["name"],
+                "count": 0 if "count" not in arm else arm["count"],
+                "success": 1 if "success" not in arm else arm["success"],
+                "failure": 1 if "failure" not in arm else arm["failure"]
+            }
             self.arms = pd.concat([self.arms, pd.DataFrame.from_records([arm_row])])
+        
+        self.arms = self.arms.dropna(axis=1)
     
+    def get_action_space_from_name(self, arm_name: str) -> Dict:
+        arm_row = self.arms.loc[self.arms["name"] == arm_name, self.action_variables]
+        return dict(zip(arm_row.columns, list(arm_row.values.flatten())))
+    
+    def get_from_action_space(self, action_space: Dict, column_name: str) -> Union[str, float]:
+        arm_row = self.arms.loc[(self.arms[list(action_space)] == pd.Series(action_space)).all(axis=1)]
+        return arm_row[column_name].item()
+    
+    def get_from_arm_name(self, arm_name: str, column_name: str) -> Union[str, float]:
+        arm_row = self.arms.loc[self.arms["name"] == arm_name]
+        return arm_row[column_name].item()
+    
+    def update_from_action_space(self, action_space: Dict, column_name: str, value: Union[str, float]) -> None:
+        self.arms.loc[(self.arms[list(action_space)] == pd.Series(action_space)).all(axis=1), column_name] = value
+
+    def update_from_arm_name(self, arm_name: str, column_name: str, value: Union[str, float]) -> None:
+        self.arms.loc[self.arms["name"] == arm_name, column_name] = value

--- a/datasets/bandits.py
+++ b/datasets/bandits.py
@@ -24,9 +24,9 @@ class Bandit:
 
         # Initialize arms in two types: 
         #   (1) action_space: a dict with keys of action variables and values of [0, 1].
-        #   (2) _arm_data: a ArmData object with a dataframe called "arms" with columns of action variables and row of arm names.
+        #   (2) arm_data: a ArmData object with a dataframe called "arms" with columns of action variables and row of arm names.
         self.action_space = {}
-        self._arm_data = self._init_arms(arms) # This method will update "terms".
+        self.arm_data = self._init_arms(arms) # This method will update "terms".
 
         # Initialize contextual variables:
         #   contexts_dict: a dict with keys of contextual variables and values of ContextAllocateData.
@@ -55,9 +55,6 @@ class Bandit:
                     self.terms.append(f"{name} * {context_name}")
         
         return contexts_dict
-
-    def get_arm_df(self) -> pd.DataFrame:
-        return self._arm_data.arms
     
     def get_actions(self) -> List:
         return list(self.action_space.keys())

--- a/datasets/policies.py
+++ b/datasets/policies.py
@@ -5,7 +5,9 @@ from typing import List, Dict, Union
 
 from datasets.bandits import Bandit
 from policies.types import PolicyType
-from policies.tscontextual.parameters import TSContextualParams
+from policies.tspostdiff.parameters import TSPostDiffParameter
+from policies.tspostdiff.ts_postdiff import thompson_sampling_postdiff
+from policies.tscontextual.parameters import TSContextualParameter
 from policies.tscontextual.ts_contextual import thompson_sampling_contextual
 from policies.tscontextual.ts_contextual import calculate_outcome
 
@@ -25,11 +27,114 @@ class TSPostDiffPolicy(Policy):
     def __init__(self, policy_configs: Dict, bandit: Bandit) -> None:
         super().__init__(policy_configs, bandit)
 
+        # Initialize a dict of versions to successes and failures e.g.:
+	    # {arm1: {success: 1, failure: 1}, arm2: {success: 1, failure: 1}, ...}
+        version_dict = {}
+        columns = []
+        for index, row in self.bandit.arm_data.arms.iterrows():
+            version_dict[row["name"]] = {
+                "success": row["success"],
+                "failure": row["failure"]
+            }
+            columns.append("{} Success".format(row["name"]).replace(" ", "_").lower())
+            columns.append("{} Failure".format(row["name"]).replace(" ", "_").lower())
+            columns.append("{} Count".format(row["name"]).replace(" ", "_").lower())
+        
+        # Initialize some parameters in ts postdiff policy.
+        self.configs["priors"] = version_dict
+
+        # Initialize parameters.
+        self.params = TSPostDiffParameter(self.configs)
+
+        # Initialize columns of simulation dataframe.
+        self.columns = ["learner", "arm", self.bandit.reward.name] + \
+            self.bandit.get_actions() + columns + ["update_batch"]
+        
+        # Initialize the indicator of update batch.
+        self.update_count = 0
+    
+    def run(self, new_learner: str) -> pd.DataFrame:
+        new_learner_df = {}
+        new_learner_df["learner"] = new_learner
+
+        # Get best action and datapoints (e.g. assigned arm, generated contexts) for the new learner.
+        best_action_name, assignment_data = thompson_sampling_postdiff(self.params)
+
+        # Record the arm name from the best action and action dataframe.
+        new_learner_df["arm"] = best_action_name
+
+        # Update arm count to arm dataframe.
+        arm_count = self.bandit.arm_data.get_from_arm_name(best_action_name, "count")
+        self.bandit.arm_data.update_from_arm_name(best_action_name, "count", arm_count + 1)
+
+        # Add arm count to each arm column.
+        for index, row in self.bandit.arm_data.arms.iterrows():
+            action_name = row["name"]
+            assignment_data[f"{action_name} Count".replace(" ", "_").lower()] = row["count"]
+
+        # Get the action space for the best arm.
+        best_action = self.bandit.arm_data.get_action_space_from_name(new_learner_df["arm"])
+
+        # Merge to a complete datapoints collection.
+        new_learner_df = new_learner_df | assignment_data | best_action
+
+        return new_learner_df
+    
+    def get_reward(self, new_learner_df: pd.DataFrame) -> pd.DataFrame:
+        true_arm_probs = dict(self.params.parameters["true_arm_probs"])
+        reward = self.bandit.reward
+
+        # Update reward for the new learner dataframe.
+        for index, row in new_learner_df.iterrows():
+            arm_name = row["arm"]
+            true_reward = np.random.binomial(reward.max_value - reward.min_value, true_arm_probs[arm_name]) + reward.min_value
+            row[reward.name] = reward.get_reward(true_reward)
+        
+        return new_learner_df
+    
+    def update_params(self, assignment_df: pd.DataFrame) -> pd.DataFrame:
+        # Record update batch indicator.
+        assignment_df["update_batch"] = self.update_count
+
+        reward = self.bandit.reward
+        arm_names = self.bandit.arm_data.arms["name"].tolist()
+
+        for arm_name in arm_names:
+            # Get reward sum and reward count for each arm.
+            sum_rewards = float(sum(assignment_df[assignment_df["arm"] == arm_name][reward.name]))
+            count_rewards = float(len(assignment_df[assignment_df["arm"] == arm_name].index))
+
+            # Scale-up reward sum if reward is normalized.
+            if reward.is_normalize:
+                sum_rewards = sum_rewards * (reward.max_value - reward.min_value) + count_rewards * reward.min_value
+            
+            # Update success (e.g. alpha) for each arm.
+            success_update = (sum_rewards - count_rewards * reward.min_value) / (reward.max_value - reward.min_value)
+            success_update = self.params.parameters["priors"][arm_name]["success"] + success_update
+
+            # Update failure (e.g. beta) for each arm.
+            failure_update = (count_rewards * reward.max_value - sum_rewards) / (reward.max_value - reward.min_value)
+            failure_update = self.params.parameters["priors"][arm_name]["failure"] + failure_update
+
+            # Update success and failure to arm dataframe and parameter's priors. 
+            self.bandit.arm_data.update_from_arm_name(arm_name, "success", success_update)
+            self.bandit.arm_data.update_from_arm_name(arm_name, "failure", failure_update)
+            self.params.update_params(arm_name, success=success_update, failure=failure_update)
+        
+        # Update the indicator.
+        self.update_count += 1
+
+        return assignment_df
+
 
 class TSContextualPolicy(Policy):
     
     def __init__(self, policy_configs: Dict, bandit: Bandit) -> None:
         super().__init__(policy_configs, bandit)
+
+        columns = []
+        for index, row in self.bandit.arm_data.arms.iterrows():
+            columns.append("{} Count".format(row["name"]).replace(" ", "_").lower())
 
         # Get regression equation terms.
         terms = self.bandit.terms
@@ -51,11 +156,11 @@ class TSContextualPolicy(Policy):
         print("regression_formula: {}".format(self.configs["regression_formula"]))
 
         # Initialize parameters.
-        self.params = TSContextualParams(self.configs)
+        self.params = TSContextualParameter(self.configs)
 
         # Initialize columns of simulation dataframe.
         self.columns = ["learner", "arm", self.bandit.reward.name] + \
-            self.bandit.get_actions() + self.bandit.get_contextual_variables() + \
+            self.bandit.get_actions() + self.bandit.get_contextual_variables() + columns + \
             ["coef_cov", "coef_mean", "variance_a", "variance_b", "precesion_draw", "coef_draw", "update_batch"]
         
         # Initialize the indicator of update batch.
@@ -69,9 +174,13 @@ class TSContextualPolicy(Policy):
         best_action, assignment_data = thompson_sampling_contextual(self.params, self.bandit.contexts_dict)
 
         # Record the arm name from the best action and action dataframe.
-        arm_df = self.bandit.get_arm_df()
-        best_arm_row = arm_df.loc[(arm_df[list(best_action)] == pd.Series(best_action)).all(axis=1)]
-        new_learner_df["arm"] = str(best_arm_row["name"][0])
+        new_learner_df["arm"] = self.bandit.arm_data.get_from_action_space(best_action, "name")
+        arm_count = self.bandit.arm_data.get_from_action_space(best_action, "count")
+        self.bandit.arm_data.update_from_action_space(best_action, "count", arm_count + 1)
+        
+        for index, row in self.bandit.arm_data.arms.iterrows():
+            action_name = row["name"]
+            assignment_data[f"{action_name} Count".replace(" ", "_").lower()] = row["count"]
 
         # Merge to a complete datapoints collection.
         new_learner_df = new_learner_df | assignment_data | best_action

--- a/examples/tscontextual_configs.json
+++ b/examples/tscontextual_configs.json
@@ -1,8 +1,8 @@
 {
     "numTrails": 1,
     "numLearners": 100,
-    "simulation": "sim1",
-    "evaluation": "eval1",
+    "simulation": "sample_tscontextual_simulation",
+    "evaluation": "sample_tscontextual_evaluation",
     "arms": [
         {
             "action_variable": "is_a1",

--- a/examples/tspostdiff_configs.json
+++ b/examples/tspostdiff_configs.json
@@ -1,0 +1,37 @@
+{
+    "numTrails": 1,
+    "numLearners": 100,
+    "simulation": "sample_tspostdiff_simulation",
+    "evaluation": "sample_tspostdiff_evaluation",
+    "arms": [
+        {
+            "action_variable": "is_a1",
+            "value": 1,
+            "name": "A1",
+            "implicit": false
+        },
+        {
+            "action_variable": "is_a1",
+            "value": 0,
+            "name": "A2",
+            "implicit": false
+        }
+    ],
+    "reward": {
+        "name": "R1",
+        "min_value": 1.0,
+        "max_value": 5.0,
+        "value_type": "ORD",
+        "normalize": true
+    },
+    "parameters": {
+        "type": "TSPOSTDIFF",
+        "batch_size": 2, 
+        "uniform_threshold": 1,
+        "tspostdiff_thresh": 0.2,
+        "true_arm_probs": {
+            "A1": 0.4,
+            "A2": 0.6
+        }
+    }
+}

--- a/metrics/confidence_interval.py
+++ b/metrics/confidence_interval.py
@@ -28,7 +28,7 @@ def draw_samples(
     return coef_draws
 
 
-def evaluate(simulation_df: pd.DataFrame) -> pd.DataFrame:
+def estimate_confidence_interval(simulation_df: pd.DataFrame) -> pd.DataFrame:
     columns = ["coef_mean", "lower_ci", "upper_ci"]
     evaluation_df = pd.DataFrame(columns=columns)
 

--- a/metrics/evaluator.py
+++ b/metrics/evaluator.py
@@ -1,0 +1,47 @@
+import pandas as pd
+
+from typing import Dict, Union
+
+from policies.types import PolicyType
+from metrics.confidence_interval import estimate_confidence_interval
+
+
+class Evaluator:
+    simulation_df: pd.DataFrame
+    metrics: Dict[str, pd.DataFrame]
+
+    def __init__(self, simulation_df: pd.DataFrame) -> None:
+        self.simulation_df = simulation_df
+        self.metrics = {}
+
+
+class TSPostDiffEvaluator(Evaluator):
+
+    def __init__(self, simulation_df: pd.DataFrame) -> None:
+        super().__init__(simulation_df)
+
+
+class TSContextualEvaluator(Evaluator):
+
+    def __init__(self, simulation_df: pd.DataFrame) -> None:
+        super().__init__(simulation_df)
+        self.metrics = {
+            "confidence_interval": self._evaluate_confidence_interval()
+        }
+    
+    def _evaluate_confidence_interval(self) -> pd.DataFrame:
+        return estimate_confidence_interval(self.simulation_df)
+
+
+class EvaluatorFactory:
+    evaluator: Union[TSPostDiffEvaluator, TSContextualEvaluator]
+
+    def __init__(self, policy_configs: Dict, simulation_df: pd.DataFrame) -> None:
+        self.evaluator = None
+        if policy_configs["type"] == PolicyType.TSCONTEXTUAL.name:
+            self.evaluator = TSContextualEvaluator(simulation_df)
+        elif policy_configs["type"] == PolicyType.TSPOSTDIFF.name:
+            self.evaluator = TSPostDiffEvaluator(simulation_df)
+    
+    def get_evaluator(self) -> Union[TSPostDiffEvaluator, TSContextualEvaluator]:
+        return self.evaluator

--- a/policies/tscontextual/parameters.py
+++ b/policies/tscontextual/parameters.py
@@ -1,13 +1,14 @@
 import pandas as pd
 from typing import Dict, List
 
+from policies.types import PolicyParameter
 from policies.tscontextual.utils import create_design_matrix, posteriors
 
-class TSContextualParams:
+class TSContextualParameter(PolicyParameter):
     parameters: Dict
     
     def __init__(self, initParams: Dict) -> None:
-        self.parameters = initParams
+        super().__init__(initParams)
     
     def update_params(self, values: pd.DataFrame, reward_name: str) -> None:
         design_matrix = create_design_matrix(

--- a/policies/tscontextual/ts_contextual.py
+++ b/policies/tscontextual/ts_contextual.py
@@ -2,12 +2,12 @@ import pandas as pd
 import numpy as np
 from scipy.stats import invgamma
 from typing import Dict, Tuple, List
-from policies.tscontextual.parameters import TSContextualParams
+from policies.tscontextual.parameters import TSContextualParameter
 from datasets.contexts import ContextAllocateData
 
 # Draw thompson sample of (reg. coeff., variance) and also select the optimal action
 def thompson_sampling_contextual(
-	params: TSContextualParams, 
+	params: TSContextualParameter, 
 	contexts: Dict[str, ContextAllocateData]
 ) -> Tuple[Dict, Dict]:
 	'''

--- a/policies/tspostdiff/parameters.py
+++ b/policies/tspostdiff/parameters.py
@@ -1,12 +1,15 @@
 import pandas as pd
 from typing import Dict
 
+from policies.types import PolicyParameter
 
-class TSPostDiffParams:
+
+class TSPostDiffParameter(PolicyParameter):
     parameters: Dict
 
     def __init__(self, initParams: Dict) -> None:
-        self.parameters = initParams
+        super().__init__(initParams)
     
-    def update_params():
-        pass
+    def update_params(self, arm_name: str, **kwargs) -> None:
+        for key, value in kwargs.items(): 
+            self.parameters["priors"][arm_name][key] = value

--- a/policies/tspostdiff/ts_postdiff.py
+++ b/policies/tspostdiff/ts_postdiff.py
@@ -1,5 +1,51 @@
 import pandas as pd
 
+from typing import Tuple, Dict
 
-def thompson_sampling_postdiff():
-    pass
+from numpy.random import choice, beta
+from policies.tspostdiff.parameters import TSPostDiffParameter
+
+
+def thompson_sampling_postdiff(params: TSPostDiffParameter) -> Tuple[Dict, Dict]:
+    # A dict of versions to successes and failures e.g.:
+	# {arm1: {success: 1, failure: 1}, arm2: {success: 1, failure: 1}, ...}
+    priors = params.parameters["priors"]
+    
+    # Threshold for TS PostDiff.
+    tspostdiff_thresh = params.parameters["tspostdiff_thresh"]
+    
+    # Drawing samples from beta discributions for two arms.
+    arm_values = list(priors.values())
+    arm_beta_1 = beta(arm_values[0]["success"], arm_values[0]["failure"])
+    arm_beta_2 = beta(arm_values[1]["success"], arm_values[1]["failure"])
+    
+    # Absolute difference between two samples
+    diff = abs(arm_beta_1 - arm_beta_2)
+
+    assignment_data = {}
+    arm_names = list(priors.keys())
+    if diff < tspostdiff_thresh:
+        # Uniform randomly picking an arm.
+        best_action_name = choice(arm_names)
+
+        for arm in arm_names:
+            assignment_data[f"{arm} Success".replace(" ", "_").lower()] = priors[arm]["success"]
+            assignment_data[f"{arm} Failure".replace(" ", "_").lower()] = priors[arm]["failure"]
+            
+        return best_action_name, assignment_data
+
+    max_beta = 0
+    for arm in arm_names:
+        assignment_data[f"{arm} Success".replace(" ", "_").lower()] = priors[arm]["success"]
+        assignment_data[f"{arm} Failure".replace(" ", "_").lower()] = priors[arm]["failure"]
+        
+        success = priors[arm]["success"]
+        failure = priors[arm]["failure"]
+        arm_beta = beta(success, failure)
+        
+        # Find higher beta sample for the optimal arm.
+        if arm_beta > max_beta:
+            max_beta = arm_beta
+            best_action_name = arm
+            
+    return best_action_name, assignment_data

--- a/policies/types.py
+++ b/policies/types.py
@@ -1,5 +1,15 @@
 from enum import Enum
 
+from typing import Dict
+
+
 class PolicyType(Enum):
     TSCONTEXTUAL = "TSCONTEXTUAL"
     TSPOSTDIFF = "TSPOSTDIFF"
+
+
+class PolicyParameter:
+    parameters: Dict
+
+    def __init__(self, params: Dict) -> None:
+        self.parameters = params


### PR DESCRIPTION
Some Major Changes:
---
- Change `arms` DataFrame in `ArmData`: Add three columns 
   - `count`: number of assigned arm; 
   - `success`: success of assigned arm, used in TS-PostDiff policy;
   - `failure`: failure of assigned arm, used in TS-PostDiff policy.
- Add some columns in TS-Contextual simulations to show number of assigned arms.
- Encapsulate evaluation to an `Evaluator` class object in `metrics/evaluator.py`.
   - Use Factory design pattern for choosing metrics for corresponding policy.
- Add TS-PostDiff policy for simulations.
   - Some columns specified to TS-PostDiff simulation results: (1) success and failure for each arm; (2) number of assigned arms.
   - See `policies/tspostdiff/ts_postdiff.py` for TS-PostDiff algorithm details.
- Move sample configs file to `examples/` and add configs file for both TS-Contextual & TS-PostDiff simulations. 