### PR TITLE
add top-two ts

### DIFF
--- a/datasets/policies.py
+++ b/datasets/policies.py
@@ -5,6 +5,8 @@ from typing import List, Dict, Union
 
 from datasets.bandits import Bandit
 from policies.types import PolicyType
+from policies.toptwots.parameters import TopTwoTSParameter
+from policies.toptwots.toptwo_ts import top_two_thompson_sampling
 from policies.tspostdiff.parameters import TSPostDiffParameter
 from policies.tspostdiff.ts_postdiff import thompson_sampling_postdiff
 from policies.tscontextual.parameters import TSContextualParameter
@@ -20,6 +22,111 @@ class Policy:
     
     def get_type(self) -> str:
         return self.configs["type"]
+
+
+class TopTwoTSPolicy(Policy):
+
+    def __init__(self, policy_configs: Dict, bandit: Bandit) -> None:
+        super().__init__(policy_configs, bandit)
+
+        # Initialize a dict of versions to successes and failures e.g.:
+	    # {arm1: {success: 1, failure: 1}, arm2: {success: 1, failure: 1}, ...}
+        version_dict = {}
+        columns = []
+        for index, row in self.bandit.arm_data.arms.iterrows():
+            version_dict[row["name"]] = {
+                "success": row["success"],
+                "failure": row["failure"]
+            }
+            columns.append("{} Success".format(row["name"]).replace(" ", "_").lower())
+            columns.append("{} Failure".format(row["name"]).replace(" ", "_").lower())
+            columns.append("{} Count".format(row["name"]).replace(" ", "_").lower())
+        
+        # Initialize some parameters in top-two ts policy.
+        self.configs["priors"] = version_dict
+
+         # Initialize parameters.
+        self.params = TopTwoTSParameter(self.configs)
+
+        # Initialize columns of simulation dataframe.
+        self.columns = ["learner", "arm", self.bandit.reward.name] + \
+            self.bandit.get_actions() + columns + ["update_batch"]
+        
+        # Initialize the indicator of update batch.
+        self.update_count = 0
+    
+    def run(self, new_learner: str) -> pd.DataFrame:
+        new_learner_df = {}
+        new_learner_df["learner"] = new_learner
+
+        # Get best action and datapoints (e.g. assigned arm, generated contexts) for the new learner.
+        best_action_name, assignment_data = top_two_thompson_sampling(self.params)
+
+        # Record the arm name from the best action and action dataframe.
+        new_learner_df["arm"] = best_action_name
+
+        # Update arm count to arm dataframe.
+        arm_count = self.bandit.arm_data.get_from_arm_name(best_action_name, "count")
+        self.bandit.arm_data.update_from_arm_name(best_action_name, "count", arm_count + 1)
+
+        # Add arm count to each arm column.
+        for index, row in self.bandit.arm_data.arms.iterrows():
+            action_name = row["name"]
+            assignment_data[f"{action_name} Count".replace(" ", "_").lower()] = row["count"]
+
+        # Get the action space for the best arm.
+        best_action = self.bandit.arm_data.get_action_space_from_name(new_learner_df["arm"])
+
+        # Merge to a complete datapoints collection.
+        new_learner_df = new_learner_df | assignment_data | best_action
+
+        return new_learner_df
+
+    def get_reward(self, new_learner_df: pd.DataFrame) -> pd.DataFrame:
+        true_arm_probs = dict(self.params.parameters["true_arm_probs"])
+        reward = self.bandit.reward
+
+        # Update reward for the new learner dataframe.
+        for index, row in new_learner_df.iterrows():
+            arm_name = row["arm"]
+            true_reward = np.random.binomial(reward.max_value - reward.min_value, true_arm_probs[arm_name]) + reward.min_value
+            row[reward.name] = reward.get_reward(true_reward)
+        
+        return new_learner_df
+    
+    def update_params(self, assignment_df: pd.DataFrame) -> pd.DataFrame:
+        # Record update batch indicator.
+        assignment_df["update_batch"] = self.update_count
+
+        reward = self.bandit.reward
+        arm_names = self.bandit.arm_data.arms["name"].tolist()
+
+        for arm_name in arm_names:
+            # Get reward sum and reward count for each arm.
+            sum_rewards = float(sum(assignment_df[assignment_df["arm"] == arm_name][reward.name]))
+            count_rewards = float(len(assignment_df[assignment_df["arm"] == arm_name].index))
+
+            # Scale-up reward sum if reward is normalized.
+            if reward.is_normalize:
+                sum_rewards = sum_rewards * (reward.max_value - reward.min_value) + count_rewards * reward.min_value
+            
+            # Update success (e.g. alpha) for each arm.
+            success_update = (sum_rewards - count_rewards * reward.min_value) / (reward.max_value - reward.min_value)
+            success_update = self.params.parameters["priors"][arm_name]["success"] + success_update
+
+            # Update failure (e.g. beta) for each arm.
+            failure_update = (count_rewards * reward.max_value - sum_rewards) / (reward.max_value - reward.min_value)
+            failure_update = self.params.parameters["priors"][arm_name]["failure"] + failure_update
+
+            # Update success and failure to arm dataframe and parameter's priors. 
+            self.bandit.arm_data.update_from_arm_name(arm_name, "success", success_update)
+            self.bandit.arm_data.update_from_arm_name(arm_name, "failure", failure_update)
+            self.params.update_params(arm_name, success=success_update, failure=failure_update)
+        
+        # Update the indicator.
+        self.update_count += 1
+
+        return assignment_df
 
 
 class TSPostDiffPolicy(Policy):
@@ -245,6 +352,8 @@ class PolicyFactory:
             self.policy = TSContextualPolicy(policy_configs, bandit)
         elif policy_configs["type"] == PolicyType.TSPOSTDIFF.name:
             self.policy = TSPostDiffPolicy(policy_configs, bandit)
+        elif policy_configs["type"] == PolicyType.TOPTWOTS.name:
+            self.policy = TopTwoTSPolicy(policy_configs, bandit)
     
     def get_policy(self) -> Union[TSPostDiffPolicy, TSContextualPolicy]:
         return self.policy

--- a/examples/toptwots_configs.json
+++ b/examples/toptwots_configs.json
@@ -1,0 +1,37 @@
+{
+    "numTrails": 1,
+    "numLearners": 100,
+    "simulation": "sample_toptwots_simulation",
+    "evaluation": "sample_toptwots_evaluation",
+    "arms": [
+        {
+            "action_variable": "is_a1",
+            "value": 1,
+            "name": "A1",
+            "implicit": false
+        },
+        {
+            "action_variable": "is_a1",
+            "value": 0,
+            "name": "A2",
+            "implicit": false
+        }
+    ],
+    "reward": {
+        "name": "R1",
+        "min_value": 1.0,
+        "max_value": 5.0,
+        "value_type": "ORD",
+        "normalize": true
+    },
+    "parameters": {
+        "type": "TOPTWOTS",
+        "batch_size": 2, 
+        "uniform_threshold": 1,
+        "epsilon_thresh": 0.2,
+        "true_arm_probs": {
+            "A1": 0.4,
+            "A2": 0.6
+        }
+    }
+}

--- a/metrics/evaluator.py
+++ b/metrics/evaluator.py
@@ -15,6 +15,12 @@ class Evaluator:
         self.metrics = {}
 
 
+class TopTwoTSEvaluator(Evaluator):
+
+    def __init__(self, simulation_df: pd.DataFrame) -> None:
+        super().__init__(simulation_df)
+
+
 class TSPostDiffEvaluator(Evaluator):
 
     def __init__(self, simulation_df: pd.DataFrame) -> None:
@@ -42,6 +48,8 @@ class EvaluatorFactory:
             self.evaluator = TSContextualEvaluator(simulation_df)
         elif policy_configs["type"] == PolicyType.TSPOSTDIFF.name:
             self.evaluator = TSPostDiffEvaluator(simulation_df)
+        elif policy_configs["type"] == PolicyType.TOPTWOTS.name:
+            self.evaluator = TopTwoTSEvaluator(simulation_df)
     
     def get_evaluator(self) -> Union[TSPostDiffEvaluator, TSContextualEvaluator]:
         return self.evaluator

--- a/policies/toptwots/parameters.py
+++ b/policies/toptwots/parameters.py
@@ -1,0 +1,15 @@
+import pandas as pd
+from typing import Dict
+
+from policies.types import PolicyParameter
+
+
+class TopTwoTSParameter(PolicyParameter):
+    parameters: Dict
+
+    def __init__(self, initParams: Dict) -> None:
+        super().__init__(initParams)
+    
+    def update_params(self, arm_name: str, **kwargs) -> None:
+        for key, value in kwargs.items(): 
+            self.parameters["priors"][arm_name][key] = value

--- a/policies/toptwots/toptwo_ts.py
+++ b/policies/toptwots/toptwo_ts.py
@@ -1,0 +1,43 @@
+import pandas as pd
+
+from typing import Tuple, Dict
+
+from numpy.random import choice, beta, uniform
+from policies.toptwots.parameters import TopTwoTSParameter
+
+
+def top_two_thompson_sampling(params: TopTwoTSParameter) -> Tuple[Dict, Dict]:
+    # A dict of versions to successes and failures e.g.:
+	# {arm1: {success: 1, failure: 1}, arm2: {success: 1, failure: 1}, ...}
+    priors = params.parameters["priors"]
+    
+    # Threshold for TopTwo TS.
+    epsilon_thresh = params.parameters["epsilon_thresh"]
+
+    assignment_data = {}
+    arm_names = list(priors.keys())
+    if uniform(0, 1) < epsilon_thresh:
+        # Uniform randomly picking an arm.
+        best_action_name = choice(arm_names)
+    
+        for arm in arm_names:
+            assignment_data[f"{arm} Success".replace(" ", "_").lower()] = priors[arm]["success"]
+            assignment_data[f"{arm} Failure".replace(" ", "_").lower()] = priors[arm]["failure"]
+        
+        return best_action_name, assignment_data
+    
+    max_beta = 0
+    for arm in arm_names:
+        assignment_data[f"{arm} Success".replace(" ", "_").lower()] = priors[arm]["success"]
+        assignment_data[f"{arm} Failure".replace(" ", "_").lower()] = priors[arm]["failure"]
+        
+        success = priors[arm]["success"]
+        failure = priors[arm]["failure"]
+        arm_beta = beta(success, failure)
+        
+        # Find higher beta sample for the optimal arm.
+        if arm_beta > max_beta:
+            max_beta = arm_beta
+            best_action_name = arm
+            
+    return best_action_name, assignment_data

--- a/policies/types.py
+++ b/policies/types.py
@@ -6,6 +6,7 @@ from typing import Dict
 class PolicyType(Enum):
     TSCONTEXTUAL = "TSCONTEXTUAL"
     TSPOSTDIFF = "TSPOSTDIFF"
+    TOPTWOTS = "TOPTWOTS"
 
 
 class PolicyParameter:


### PR DESCRIPTION
Add Top-Two TS policy
---
- Check `datasets/policies.py` for `TopTwoTSPolicy`, which is the main part of the Top-Two TS policy.
- Check `policies/toptwo_ts.py` for `top_two_thompson_sampling`, which is the algorithm code.
- Check `metrics/evaluator.py` for `TopTwoTSEvaluator`, which is the metrics for evaluating Top-Two TS results. Now the metrics are empty. This should be added later.
- Check `examples/toptwots_configs.json`, which is a sample configs file for Top-Two TS. Note that Top-Two TS policy supports arms (n > 2).