### PR TITLE
Add burn-in

### DIFF
--- a/datasets/policies.py
+++ b/datasets/policies.py
@@ -49,7 +49,7 @@ class TopTwoTSPolicy(Policy):
         self.params = TopTwoTSParameter(self.configs)
 
         # Initialize columns of simulation dataframe.
-        self.columns = ["learner", "arm", self.bandit.reward.name] + \
+        self.columns = ["learner", "ur_coldstart", "arm", self.bandit.reward.name] + \
             self.bandit.get_actions() + columns + ["update_batch"]
         
         # Initialize the indicator of update batch.
@@ -58,6 +58,7 @@ class TopTwoTSPolicy(Policy):
     def run(self, new_learner: str) -> pd.DataFrame:
         new_learner_df = {}
         new_learner_df["learner"] = new_learner
+        new_learner_df["ur_coldstart"] = int(self.params.is_burn_in())
 
         # Get best action and datapoints (e.g. assigned arm, generated contexts) for the new learner.
         best_action_name, assignment_data = top_two_thompson_sampling(self.params)
@@ -154,7 +155,7 @@ class TSPostDiffPolicy(Policy):
         self.params = TSPostDiffParameter(self.configs)
 
         # Initialize columns of simulation dataframe.
-        self.columns = ["learner", "arm", self.bandit.reward.name] + \
+        self.columns = ["learner", "ur_coldstart", "arm", self.bandit.reward.name] + \
             self.bandit.get_actions() + columns + ["update_batch"]
         
         # Initialize the indicator of update batch.
@@ -163,6 +164,7 @@ class TSPostDiffPolicy(Policy):
     def run(self, new_learner: str) -> pd.DataFrame:
         new_learner_df = {}
         new_learner_df["learner"] = new_learner
+        new_learner_df["ur_coldstart"] = int(self.params.is_burn_in())
 
         # Get best action and datapoints (e.g. assigned arm, generated contexts) for the new learner.
         best_action_name, assignment_data = thompson_sampling_postdiff(self.params)
@@ -266,7 +268,7 @@ class TSContextualPolicy(Policy):
         self.params = TSContextualParameter(self.configs)
 
         # Initialize columns of simulation dataframe.
-        self.columns = ["learner", "arm", self.bandit.reward.name] + \
+        self.columns = ["learner", "ur_coldstart", "arm", self.bandit.reward.name] + \
             self.bandit.get_actions() + self.bandit.get_contextual_variables() + columns + \
             ["coef_cov", "coef_mean", "variance_a", "variance_b", "precesion_draw", "coef_draw", "update_batch"]
         
@@ -276,6 +278,7 @@ class TSContextualPolicy(Policy):
     def run(self, new_learner: str) -> pd.DataFrame:
         new_learner_df = {}
         new_learner_df["learner"] = new_learner
+        new_learner_df["ur_coldstart"] = int(self.params.is_burn_in())
 
         # Get best action and datapoints (e.g. assigned arm, generated contexts) for the new learner.
         best_action, assignment_data = thompson_sampling_contextual(self.params, self.bandit.contexts_dict)

--- a/policies/toptwots/toptwo_ts.py
+++ b/policies/toptwots/toptwo_ts.py
@@ -7,15 +7,35 @@ from policies.toptwots.parameters import TopTwoTSParameter
 
 
 def top_two_thompson_sampling(params: TopTwoTSParameter) -> Tuple[Dict, Dict]:
+    parameters = params.parameters
+
     # A dict of versions to successes and failures e.g.:
 	# {arm1: {success: 1, failure: 1}, arm2: {success: 1, failure: 1}, ...}
-    priors = params.parameters["priors"]
+    priors = parameters["priors"]
+
+    # Burn-in size
+    uniform_threshold = parameters["uniform_threshold"]
     
     # Threshold for TopTwo TS.
-    epsilon_thresh = params.parameters["epsilon_thresh"]
+    epsilon_thresh = parameters["epsilon_thresh"]
 
     assignment_data = {}
     arm_names = list(priors.keys())
+
+    # UR Cold Start
+    if uniform_threshold != 0:
+		# Decrease the burn-in size by 1
+        parameters["uniform_threshold"] -= 1
+		
+		# Uniform randomly picking an arm.
+        best_action_name = choice(arm_names)
+        
+        for arm in arm_names:
+            assignment_data[f"{arm} Success".replace(" ", "_").lower()] = priors[arm]["success"]
+            assignment_data[f"{arm} Failure".replace(" ", "_").lower()] = priors[arm]["failure"]
+            
+        return best_action_name, assignment_data
+
     if uniform(0, 1) < epsilon_thresh:
         # Uniform randomly picking an arm.
         best_action_name = choice(arm_names)

--- a/policies/types.py
+++ b/policies/types.py
@@ -14,3 +14,12 @@ class PolicyParameter:
 
     def __init__(self, params: Dict) -> None:
         self.parameters = params
+
+        if "uniform_threshold" not in self.parameters:
+            self.parameters["uniform_threshold"] = 0
+        
+        if "batch_size" not in self.parameters:
+            self.parameters["batch_size"] = 1
+    
+    def is_burn_in(self) -> bool:
+        return self.parameters["uniform_threshold"] != 0


### PR DESCRIPTION
Add Burn-in size to coldstart Uniform Random in TS-Contextual, TS-PostDiff, and TopTwo-TS policies.
- Add `ur_coldstart` in simulation dataframe for indicating whether arms are assigned within burn-in size.