### PR TITLE
add multi-policies simulation in sequence

### DIFF
--- a/datasets/bandits.py
+++ b/datasets/bandits.py
@@ -47,7 +47,13 @@ class Bandit:
         for context in contexts:
             context = dict(context)
             context_name = context["name"]
-            contexts_dict[context_name] = ContextAllocateData(context["values"], context["allocations"])
+            contexts_dict[context_name] = ContextAllocateData(
+                context["min_value"], 
+                context["max_value"], 
+                context["value_type"], 
+                context["normalize"], 
+                context["distribution"]
+            )
             if context['extra'] is True:
                 self.terms.append(context_name)
             if context['interaction'] is True:
@@ -61,3 +67,10 @@ class Bandit:
     
     def get_contextual_variables(self) -> List:
         return list(self.contexts_dict.keys())
+    
+    def get_noncont_contextual_variables(self) -> List:
+        lst = []
+        for context in list(self.contexts_dict.keys()):
+            if self.contexts_dict[context].type != "CONT":
+                lst.append(context)
+        return lst

--- a/datasets/contexts.py
+++ b/datasets/contexts.py
@@ -25,7 +25,7 @@ class ContextAllocateData:
         if dis_type is not None:
             random_val = eval(dis_type).rvs(**distribution_copy)
             if self.type != "CONT":
-                random_val = np.floor(random_val)
+                random_val = np.around(random_val)
             random_val = np.clip(random_val, self.min_val, self.max_val)
             
             if self.normalize:

--- a/datasets/contexts.py
+++ b/datasets/contexts.py
@@ -1,21 +1,35 @@
-from typing import List
+from typing import List, Dict
+from scipy.stats import randint, bernoulli, uniform, norm
+
+import numpy as np
+
 
 class ContextAllocateData:
-    values: List[float]
-    allocations: List[float]
+    min_val: float
+    max_val: float
+    type: str
+    normalize: bool
+    distribution: Dict
 
-    def __init__(self, values: List, allocations: List) -> None:
-        if len(values) == 0:
-            print("no context values!")
-            return None
+    def __init__(self, min_val: float, max_val: float, type: str, normalize: bool, distribution: Dict) -> None:
+        self.min_val = min_val
+        self.max_val = max_val
+        self.type = type
+        self.normalize = normalize
+        self.distribution = distribution
 
-        if len(values) != len(allocations):
-            print("can't allocate context values!")
-            return None
+    def get_rvs(self) -> float:
+        distribution_copy = self.distribution.copy()
+        dis_type = distribution_copy.pop('type', None)
         
-        if sum(allocations) != 1:
-            print("allocation invalid!")
-            return None
-        
-        self.values = values
-        self.allocations = allocations
+        if dis_type is not None:
+            random_val = eval(dis_type).rvs(**distribution_copy)
+            if self.type != "CONT":
+                random_val = np.floor(random_val)
+            random_val = np.clip(random_val, self.min_val, self.max_val)
+            
+            if self.normalize:
+                random_val = (random_val - self.min_val) / (self.max_val - self.min_val)
+            
+            return round(random_val, 2)
+        return None

--- a/datasets/rewards.py
+++ b/datasets/rewards.py
@@ -51,7 +51,7 @@ class RewardData:
     def get_reward(self, raw_reward: float) -> float:
         """ Return the reward value given the normalization option in configs file. """
         if self.value_type != "CONT":
-            raw_reward = np.floor(raw_reward)
+            raw_reward = np.around(raw_reward)
         raw_reward = np.clip(raw_reward, self.min_value, self.max_value)
 
         if self.is_normalize and (self.min_value != 0.0 or self.max_value != 1.0):

--- a/examples/multipolicies_contextual.json
+++ b/examples/multipolicies_contextual.json
@@ -1,0 +1,98 @@
+{
+    "numTrails": 1,
+    "numLearners": 100,
+    "simulation": "sample_multipolicies_context_simulation",
+    "evaluation": "sample_multipolicies_context_simulation",
+    "arms": [
+        {
+            "action_variable": "is_a1",
+            "value": 1,
+            "name": "A1",
+            "implicit": false
+        },
+        {
+            "action_variable": "is_a2",
+            "value": 1,
+            "name": "A2",
+            "implicit": false
+        },
+        {
+            "action_variable": null,
+            "value": 0,
+            "name": "A3",
+            "implicit": true
+        }
+    ],
+    "contexts": [
+        {
+            "name": "C1",
+            "min_value": 0.0,
+            "max_value": 1.0,
+            "value_type": "BIN",
+            "sample_thres": 15,
+            "interaction": true,
+            "extra": true,
+            "values": [0.0, 1.0],
+            "allocations": [0.5, 0.5]
+        },
+        {
+            "name": "C2",
+            "min_value": 0.0,
+            "max_value": 5.0,
+            "value_type": "ORD",
+            "sample_thres": 15,
+            "interaction": true,
+            "extra": false,
+            "values": [0.0, 0.25, 0.5, 0.75, 1.0],
+            "allocations": [0.2, 0.2, 0.2, 0.2, 0.2]
+        },
+        {
+            "name": "C3",
+            "min_value": 0.0,
+            "max_value": 1.0,
+            "value_type": "CONT",
+            "sample_thres": 15,
+            "interaction": false,
+            "extra": true,
+            "values": [0.0, 0.1234, 0.3456, 0.5183, 0.6667, 0.7893, 0.9943, 1.0],
+            "allocations": [0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125, 0.125]
+        }
+    ],
+    "reward": {
+        "name": "R1",
+        "min_value": 1.0,
+        "max_value": 5.0,
+        "value_type": "ORD",
+        "normalize": true
+    },
+    "parameters": [
+        {
+            "name": "policy1",
+            "type": "TSCONTEXTUAL",
+            "variance_a": 2, 
+            "variance_b": 1, 
+            "batch_size": 2, 
+            "uniform_threshold": 1,
+            "include_intercept": 1,
+            "regression_formula": null,
+            "true_estimate": "R1 ~ is_a1 + is_a2 + C1 + is_a1 * C1 + is_a2 * C1 + is_a1 * C2 + is_a2 * C2 + C3",
+            "true_coef_mean": [0.2, 0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            "unique_reward": false,
+            "unique_contexts": false
+        },
+        {
+            "name": "policy2",
+            "type": "TSCONTEXTUAL",
+            "variance_a": 2, 
+            "variance_b": 1, 
+            "batch_size": 2, 
+            "uniform_threshold": 1,
+            "include_intercept": 1,
+            "regression_formula": null,
+            "true_estimate": "R1 ~ is_a1 + is_a2 + C1 + is_a1 * C1 + is_a2 * C1 + is_a1 * C2 + is_a2 * C2 + C3",
+            "true_coef_mean": [0.2, 0.5, 0.2, 0.3, 0.0, 0.0, 0.0, 0.0, 0.0],
+            "unique_reward": true,
+            "unique_contexts": true
+        }
+    ]
+}

--- a/examples/multipolicies_non_contextual.json
+++ b/examples/multipolicies_non_contextual.json
@@ -1,0 +1,51 @@
+{
+    "numTrails": 1,
+    "numLearners": 100,
+    "simulation": "sample_multipolicies_noncontext_simulation",
+    "evaluation": "sample_multipolicies_noncontext_evaluation",
+    "arms": [
+        {
+            "action_variable": "is_a1",
+            "value": 1,
+            "name": "A1",
+            "implicit": false
+        },
+        {
+            "action_variable": "is_a1",
+            "value": 0,
+            "name": "A2",
+            "implicit": false
+        }
+    ],
+    "reward": {
+        "name": "R1",
+        "min_value": 1.0,
+        "max_value": 5.0,
+        "value_type": "ORD",
+        "normalize": true
+    },
+    "parameters": [{
+        "name": "policy1",
+        "type": "TOPTWOTS",
+        "batch_size": 2, 
+        "uniform_threshold": 1,
+        "epsilon_thresh": 0.2,
+        "true_arm_probs": {
+            "A1": 0.4,
+            "A2": 0.6
+        },
+        "unique_reward": false
+    }, {
+        "name": "policy2",
+        "type": "TSPOSTDIFF",
+        "batch_size": 2, 
+        "uniform_threshold": 1,
+        "tspostdiff_thresh": 0.2,
+        "true_arm_probs": {
+            "A1": 0.4,
+            "A2": 0.6
+        },
+        "unique_reward": true
+    }
+]
+}

--- a/main.py
+++ b/main.py
@@ -43,7 +43,10 @@ def simulate(
     contexts = list(configs["contexts"]) if "contexts" in configs else None
     reward = dict(configs["reward"])
 
-    all_params = list(configs["parameters"])
+    if type(configs["parameters"]) == dict:
+        all_params =  list([configs["parameters"]])
+    else:
+        all_params = list(configs["parameters"])
     all_policies = []
     for init_params in all_params:
         # Initialize bandit settings.

--- a/main.py
+++ b/main.py
@@ -112,7 +112,7 @@ def simulate(
                 # Update rewards for the new learner.
                 # Copy reward values if policy is not unique in rewards.
                 if not is_unique_reward:
-                    new_learner_df[policy.get_reward_column_name()] = simulation_df.loc[trail * horizon + learner, policy.get_reward_column_name()]
+                    new_learner_df.loc[0, policy.get_reward_column_name()] = simulation_df.loc[trail * horizon + learner, policy.get_reward_column_name()]
                     new_learner_df = new_learner_df.rename(index={0: trail * horizon + learner})
                 else:
                     new_learner_df = policy.get_reward(new_learner_df)
@@ -133,6 +133,16 @@ def simulate(
 
                     # Re-initialize the update batch of datapoints.
                     assignment_df = pd.DataFrame(columns=columns)
+        
+        # Concate the remaining assignment dataframe to the simulation dataframe.
+        if len(assignment_df.index) > 0:
+            assignment_df[policy.get_udpate_batch_column_name()] = policy.update_count
+
+            # Merge to simulation dataframe.
+            if not is_unique_reward:
+                simulation_df = simulation_df.fillna(assignment_df)
+            else:
+                simulation_df = pd.concat([simulation_df, assignment_df])
 
         print("{} arm data:".format(policy.get_name()))
         print(policy.bandit.arm_data.arms)

--- a/metrics/arm_summary.py
+++ b/metrics/arm_summary.py
@@ -1,8 +1,18 @@
 import pandas as pd
 import numpy as np
 
+from typing import List
 
-def arm_summary(simulation_df: pd.DataFrame, reward_name: str) -> pd.DataFrame:
-    arm_group = simulation_df.groupby(by=["arm"]).agg({reward_name: ['min', 'max', 'mean', 'std', 'sem', 'count'], 'arm' : ['count']})
+
+def arm_summary(simulation_dfs: List[pd.DataFrame], reward_name: str) -> pd.DataFrame:
+    trail_column = ["trail_number"] + simulation_dfs[0].columns
     
-    return arm_group.unstack(level=0).unstack()
+    all_simulation_df = pd.DataFrame(columns=trail_column)
+    
+    for i in range(len(simulation_dfs)):
+        simulation_dfs[0]["trail_number"] = i
+        all_simulation_df = pd.concat([all_simulation_df, simulation_dfs[i]])
+    
+    arm_group = all_simulation_df.groupby(by=["trail_number", "arm"]).agg({reward_name: ['min', 'max', 'mean', 'std', 'sem', 'count'], 'arm' : ['count']})
+    
+    return arm_group

--- a/metrics/arm_summary.py
+++ b/metrics/arm_summary.py
@@ -1,0 +1,8 @@
+import pandas as pd
+import numpy as np
+
+
+def arm_summary(simulation_df: pd.DataFrame, reward_name: str) -> pd.DataFrame:
+    arm_group = simulation_df.groupby(by=["arm"]).agg({reward_name: ['min', 'max', 'mean', 'std', 'sem', 'count'], 'arm' : ['count']})
+    
+    return arm_group.unstack(level=0).unstack()

--- a/metrics/confidence_interval.py
+++ b/metrics/confidence_interval.py
@@ -5,6 +5,15 @@ from scipy.stats import invgamma, t, sem
 
 from typing import List, Tuple
 
+def mean_confidence_interval_quantile(
+    samples: List[float], 
+    confidence: float = 0.95
+) -> Tuple[float, float, float]:
+    m = np.mean(samples)
+    lower = np.quantile(np.asarray(samples), (1 - confidence) / 2.)
+    upper = np.quantile(np.asarray(samples), confidence + (1 - confidence) / 2.)
+    
+    return m, lower, upper
 
 def mean_confidence_interval_sem(
     samples: List[float], 
@@ -70,7 +79,7 @@ def estimate_confidence_interval(simulation_df: pd.DataFrame, formula: str) -> p
 
     for sample_ind in range(coef_draws.shape[0]):
         samples = coef_draws[sample_ind]
-        sample_coef_mean, sample_lower_ci, sample_upper_ci = mean_confidence_interval_sem(samples)
+        sample_coef_mean, sample_lower_ci, sample_upper_ci = mean_confidence_interval_quantile(samples)
         sample_evaluation = {
             "term": vars_list[sample_ind],
             "coef_mean": float(sample_coef_mean), 

--- a/metrics/confidence_interval.py
+++ b/metrics/confidence_interval.py
@@ -58,36 +58,50 @@ def draw_samples(
     return coef_draws
 
 
-def estimate_confidence_interval(simulation_df: pd.DataFrame, formula: str) -> pd.DataFrame:
-    columns = ["term", "coef_mean", "lower_bound", "upper_bound"]
-    evaluation_df = pd.DataFrame(columns=columns)
+def estimate_confidence_interval(simulation_dfs: List[pd.DataFrame], formula: str) -> pd.DataFrame:
+    columns = ["term", "coef_mean", "lower_bound", "upper_bound", "trail"]
+    all_evaluation_df = []
 
-    latest_params = simulation_df.iloc[-1]
+    for i in range(len(simulation_dfs)):
+        evaluation_df = pd.DataFrame(columns=columns)
+        latest_params = simulation_dfs[i].iloc[-1]
+        
+        # print(f"latest_params: {latest_params}")
 
-    formula = formula.strip()
-    all_vars_str = formula.split('~')[1].strip()
-    dependent_var = formula.split('~')[0].strip()
-    vars_list = all_vars_str.split('+')
-    vars_list = ["INTERCEPT"] + list(map(str.strip, vars_list))
+        formula = formula.strip()
+        all_vars_str = formula.split('~')[1].strip()
+        dependent_var = formula.split('~')[0].strip()
+        vars_list = all_vars_str.split('+')
+        vars_list = ["INTERCEPT"] + list(map(str.strip, vars_list))
 
-    mean = np.asarray(latest_params['coef_mean'])
-    cov = np.asarray(latest_params['coef_cov'])
-    variance_a = float(latest_params['variance_a'])
-    variance_b = float(latest_params['variance_b'])
+        mean = np.asarray(latest_params['coef_mean'])
+        cov = np.asarray(latest_params['coef_cov'])
+        variance_a = float(latest_params['variance_a'])
+        variance_b = float(latest_params['variance_b'])
+        
+        # print(f"mean: {mean}")
+        # print(f"cov: {cov}")
+        # print(f"variance_a: {variance_a}")
+        # print(f"variance_b: {variance_b}")
 
-    coef_draws = draw_samples(variance_a, variance_b, mean, cov).T
+        coef_draws = draw_samples(variance_a, variance_b, mean, cov).T
 
-    for sample_ind in range(coef_draws.shape[0]):
-        samples = coef_draws[sample_ind]
-        sample_coef_mean, sample_lower_ci, sample_upper_ci = mean_confidence_interval_quantile(samples)
-        sample_evaluation = {
-            "term": vars_list[sample_ind],
-            "coef_mean": float(sample_coef_mean), 
-            "lower_bound": float(sample_lower_ci), 
-            "upper_bound": float(sample_upper_ci)
-        }
-        evaluation_df = pd.concat([evaluation_df, pd.DataFrame.from_records([sample_evaluation])])
+        for sample_ind in range(coef_draws.shape[0]):
+            samples = coef_draws[sample_ind]
+            sample_coef_mean, sample_lower_ci, sample_upper_ci = mean_confidence_interval_quantile(samples)
+            sample_evaluation = {
+                "trail": i,
+                "term": vars_list[sample_ind],
+                "coef_mean": float(sample_coef_mean), 
+                "lower_bound": float(sample_lower_ci), 
+                "upper_bound": float(sample_upper_ci)
+            }
+            evaluation_df = pd.concat([evaluation_df, pd.DataFrame.from_records([sample_evaluation])])
+        all_evaluation_df.append(evaluation_df)
+        # evaluation_df = evaluation_df.assign(TermIndex=range(len(evaluation_df))).set_index('TermIndex')
+        # all_evaluation_df = pd.concat([all_evaluation_df, evaluation_df])
 
-    evaluation_df = evaluation_df.assign(TermIndex=range(len(evaluation_df))).set_index('TermIndex')
+    all_evaluation = pd.concat(all_evaluation_df)
+    
+    return all_evaluation.groupby(by=["trail", "term"]).agg({"coef_mean": ["first"], "lower_bound": ["first"], "upper_bound": ["first"]})
 
-    return evaluation_df

--- a/metrics/context_summary.py
+++ b/metrics/context_summary.py
@@ -1,8 +1,18 @@
 import pandas as pd
 import numpy as np
 
+from typing import List
 
-def context_summary(simulation_df: pd.DataFrame, reward_name: str, context: str) -> pd.DataFrame:
-    context_group = simulation_df.groupby(by=[context, "arm"]).agg({reward_name: ['min', 'max', 'mean', 'std', 'sem', 'count'], 'arm' : ['count']})
 
-    return context_group.stack(level=[0, 1]).unstack(level=[1, 0])
+def context_summary(simulation_dfs: List[pd.DataFrame], reward_name: str, context: str) -> pd.DataFrame:
+    trail_column = ["trail_number"] + simulation_dfs[0].columns
+    
+    all_simulation_df = pd.DataFrame(columns=trail_column)
+    
+    for i in range(len(simulation_dfs)):
+        simulation_dfs[0]["trail_number"] = i
+        all_simulation_df = pd.concat([all_simulation_df, simulation_dfs[i]])
+    
+    context_group = all_simulation_df.groupby(by=["trail_number", context, "arm"]).agg({reward_name: ['min', 'max', 'mean', 'std', 'sem', 'count'], 'arm' : ['count']})
+
+    return context_group

--- a/metrics/context_summary.py
+++ b/metrics/context_summary.py
@@ -1,0 +1,8 @@
+import pandas as pd
+import numpy as np
+
+
+def context_summary(simulation_df: pd.DataFrame, reward_name: str, context: str) -> pd.DataFrame:
+    context_group = simulation_df.groupby(by=[context, "arm"]).agg({reward_name: ['min', 'max', 'mean', 'std', 'sem', 'count'], 'arm' : ['count']})
+
+    return context_group.stack(level=[0, 1]).unstack(level=[1, 0])

--- a/metrics/evaluator.py
+++ b/metrics/evaluator.py
@@ -8,38 +8,39 @@ from metrics.confidence_interval import estimate_confidence_interval
 from metrics.wald_test import perfrom_wald_test
 from metrics.arm_summary import arm_summary
 from metrics.context_summary import context_summary
+from metrics.power_fpr import power_fpr
 
 
 class Evaluator:
     policy: Policy
-    simulation_df: pd.DataFrame
+    simulation_dfs: List[pd.DataFrame]
     metrics: Dict[str, pd.DataFrame]
 
-    def __init__(self, simulation_df: pd.DataFrame, policy: Policy) -> None:
-        self.simulation_df = simulation_df
+    def __init__(self, simulation_dfs: List[pd.DataFrame], policy: Policy) -> None:
+        self.simulation_dfs = simulation_dfs
         self.policy = policy
         self.metrics = {}
 
 
 class TopTwoTSEvaluator(Evaluator):
 
-    def __init__(self, simulation_df: pd.DataFrame, policy: Policy) -> None:
-        super().__init__(simulation_df, policy)
+    def __init__(self, simulation_dfs: List[pd.DataFrame], policy: Policy) -> None:
+        super().__init__(simulation_dfs, policy)
         self.metrics = {
             "wald_test": self._test_wald()
         }
     
     def _test_wald(self) -> pd.DataFrame:
-        return perfrom_wald_test(self.simulation_df, self.policy)
+        return perfrom_wald_test(self.simulation_dfs, self.policy)
     
     def _arm_summary(self, reward: str) -> pd.DataFrame:
-        return arm_summary(self.simulation_df, reward)
+        return arm_summary(self.simulation_dfs, reward)
 
 
 class TSPostDiffEvaluator(Evaluator):
 
-    def __init__(self, simulation_df: pd.DataFrame, policy: Policy) -> None:
-        super().__init__(simulation_df, policy)
+    def __init__(self, simulation_dfs: List[pd.DataFrame], policy: Policy) -> None:
+        super().__init__(simulation_dfs, policy)
         self.metrics = {
             "wald_test": self._test_wald()
         }
@@ -53,8 +54,8 @@ class TSPostDiffEvaluator(Evaluator):
 
 class TSContextualEvaluator(Evaluator):
 
-    def __init__(self, simulation_df: pd.DataFrame, policy: Policy) -> None:
-        super().__init__(simulation_df, policy)
+    def __init__(self, simulation_dfs: List[pd.DataFrame], policy: Policy) -> None:
+        super().__init__(simulation_dfs, policy)
         regression_formula = self.policy.configs["regression_formula"]
         reward = self.policy.bandit.reward.name
         noncont_contexts = self.policy.bandit.get_noncont_contextual_variables()
@@ -64,28 +65,37 @@ class TSContextualEvaluator(Evaluator):
         }
         for context in noncont_contexts:
             self.metrics["{}_summary".format(context)] = self._context_summary(reward, context)
+        
+        self.metrics["wald_test"] = self._test_wald()
+        self.metrics["power_fpr"] = self._compute_power_fpr(reward)
 
     def _evaluate_confidence_interval(self, regression_formula: str) -> pd.DataFrame:
-        return estimate_confidence_interval(self.simulation_df, regression_formula)
+        return estimate_confidence_interval(self.simulation_dfs, regression_formula)
 
     def _arm_summary(self, reward: str) -> pd.DataFrame:
-        return arm_summary(self.simulation_df, reward)
+        return arm_summary(self.simulation_dfs, reward)
     
     def _context_summary(self, reward: str, context: str) -> pd.DataFrame:
-        return context_summary(self.simulation_df, reward, context)
+        return context_summary(self.simulation_dfs, reward, context)
+
+    def _test_wald(self) -> pd.DataFrame:
+        return perfrom_wald_test(self.simulation_dfs, self.policy)
+    
+    def _compute_power_fpr(self, reward: str) -> pd.DataFrame:
+        return power_fpr(self.simulation_dfs, self.metrics["wald_test"], reward)
 
 
 class EvaluatorFactory:
-    evaluator: Union[TSPostDiffEvaluator, TSContextualEvaluator]
+    evaluator: Union[TopTwoTSEvaluator, TSPostDiffEvaluator, TSContextualEvaluator]
 
-    def __init__(self, simulation_df: pd.DataFrame, policy: Policy) -> None:
+    def __init__(self, simulation_dfs: List[pd.DataFrame], policy: Policy) -> None:
         self.evaluator = None
         if policy.get_type() == PolicyType.TSCONTEXTUAL.name:
-            self.evaluator = TSContextualEvaluator(simulation_df, policy)
+            self.evaluator = TSContextualEvaluator(simulation_dfs, policy)
         elif policy.get_type() == PolicyType.TSPOSTDIFF.name:
-            self.evaluator = TSPostDiffEvaluator(simulation_df, policy)
+            self.evaluator = TSPostDiffEvaluator(simulation_dfs, policy)
         elif policy.get_type() == PolicyType.TOPTWOTS.name:
-            self.evaluator = TopTwoTSEvaluator(simulation_df, policy)
+            self.evaluator = TopTwoTSEvaluator(simulation_dfs, policy)
     
     def get_evaluator(self) -> Union[TSPostDiffEvaluator, TSContextualEvaluator]:
         return self.evaluator

--- a/metrics/power_fpr.py
+++ b/metrics/power_fpr.py
@@ -1,0 +1,43 @@
+import pandas as pd
+import numpy as np
+
+from typing import List
+
+
+def compute_power(
+    simulation_dfs: List[pd.DataFrame], 
+    wald_dfs: pd.DataFrame, 
+    reward_name: str
+) -> pd.DataFrame:
+    mean_rewards = []
+    for simulation_df in simulation_dfs:
+        mean_reward = np.mean(simulation_df[reward_name])
+        mean_rewards.append(mean_reward)
+    
+    avg_mean_reward = np.mean(mean_rewards)
+    power = np.mean(wald_dfs["wald_statistics"] > 1.96)
+    
+    return avg_mean_reward, power
+
+
+def compute_fpr(wald_dfs: pd.DataFrame) -> pd.DataFrame:
+    fpr = np.mean(wald_dfs["wald_significant"])
+    
+    return fpr
+
+
+def power_fpr(    
+    simulation_dfs: List[pd.DataFrame], 
+    wald_dfs: pd.DataFrame, 
+    reward_name: str
+) -> pd.DataFrame:
+    avg_mean_reward, power = compute_power(simulation_dfs, wald_dfs, reward_name)
+    fpr = compute_fpr(wald_dfs)
+    
+    power_fpr_df = {
+        "avg_mean_reward": avg_mean_reward,
+        "power": power,
+        "fpr": fpr
+    }
+    
+    return pd.DataFrame([power_fpr_df]).reset_index(drop=True)

--- a/metrics/wald_test.py
+++ b/metrics/wald_test.py
@@ -4,7 +4,7 @@ from scipy.stats import norm
 
 from typing import List, Tuple, Union
 
-from datasets.policies import TopTwoTSPolicy, TSPostDiffPolicy
+from datasets.policies import TopTwoTSPolicy, TSPostDiffPolicy, TSContextualPolicy
 
 np.seterr(divide='ignore',invalid='ignore')
 
@@ -27,36 +27,43 @@ def wald_test_statistics(
 
 
 def perfrom_wald_test(
-    simulation_df: pd.DataFrame, 
-    policy: Union[TopTwoTSPolicy, TSPostDiffPolicy]
+    simulation_dfs: List[pd.DataFrame], 
+    policy: Union[TopTwoTSPolicy, TSPostDiffPolicy, TSContextualPolicy]
 ) -> pd.DataFrame:
-    arm_dict = {}
-    count = 0
-    for index, row in policy.bandit.arm_data.arms.iterrows():
-        arm_df = {}
+    trail_df = pd.DataFrame()
+    for simulation_df in simulation_dfs:
+        arm_dict = {}
+        success_failure_names = []
+        count = 0
+        for index, row in policy.bandit.arm_data.arms.iterrows():
+            arm_name = row["name"]
+            arm_success = "{} Success".format(arm_name).replace(" ", "_").lower()
+            arm_failure = "{} Failure".format(arm_name).replace(" ", "_").lower()
+            arm_count = "{} Count".format(arm_name).replace(" ", "_").lower()
+            success_failure_names.extend([arm_success, arm_failure, arm_count])
 
-        arm_name = row["name"]
-        arm_success = "{} Success".format(arm_name).replace(" ", "_").lower()
-        arm_count = "{} Count".format(arm_name).replace(" ", "_").lower()
+            arm_dict[count] = {
+                "success": list(simulation_df.iloc[-1:][arm_success]),
+                "count": list(simulation_df.iloc[-1:][arm_count])
+            }
 
-        arm_dict[count] = {
-            "success": simulation_df[arm_success].tolist(),
-            "count": simulation_df[arm_count].tolist()
+            count += 1
+
+        wald_statistics, pval = wald_test_statistics(
+            arm_dict[0]["success"], arm_dict[1]["success"], 
+            arm_dict[0]["count"], arm_dict[1]["count"]
+        )
+
+        wald_df = {
+            "wald_statistics": wald_statistics,
+            "wald_p_value": pval,
+            "wald_significant": (pval < 0.05).astype(int)
         }
+        
+        latest_success_failure = simulation_df.iloc[-1:][success_failure_names].reset_index(drop=True)
+        evaluation_df = pd.concat([latest_success_failure, pd.DataFrame(wald_df).reset_index(drop=True)], axis=1)
+        trail_df = pd.concat([trail_df, evaluation_df])
+    
+    trail_df = trail_df.assign(TrailIndex=range(len(trail_df))).set_index('TrailIndex')
 
-        count += 1
-
-    wald_statistics, pval = wald_test_statistics(
-        arm_dict[0]["success"], arm_dict[1]["success"], 
-        arm_dict[0]["count"], arm_dict[1]["count"]
-    )
-
-    wald_df = {
-        "wald_statistics": wald_statistics,
-        "wald_p_value": pval,
-        "wald_significant": (pval < 0.05).astype(int)
-    }
-
-    evaluation_df = pd.concat([simulation_df, pd.DataFrame(wald_df).reset_index(drop=True)], axis=1)
-
-    return evaluation_df
+    return trail_df

--- a/policies/tscontextual/ts_contextual.py
+++ b/policies/tscontextual/ts_contextual.py
@@ -8,7 +8,7 @@ from datasets.contexts import ContextAllocateData
 # Draw thompson sample of (reg. coeff., variance) and also select the optimal action
 def thompson_sampling_contextual(
 	params: TSContextualParameter, 
-	contexts: Dict[str, ContextAllocateData]
+	contextual_vars_dict: Dict[str, float]
 ) -> Tuple[Dict, Dict]:
 	'''
 	thompson sampling policy with contextual information.
@@ -37,10 +37,10 @@ def thompson_sampling_contextual(
 	contextual_vars = parameters['contextual_variables']
 
 	assignment_data = {}
-	contextual_vars_dict = {}
-	for var in contextual_vars: 
-		contextual_vars_dict[var] = np.random.choice(contexts[var].values, size=1, p=contexts[var].allocations)[0]
-		assignment_data[var] = contextual_vars_dict[var]
+	# contextual_vars_dict = {}
+	# for var in contextual_vars: 
+	# 	contextual_vars_dict[var] = np.random.choice(contexts[var].values, size=1, p=contexts[var].allocations)[0]
+	# 	assignment_data[var] = contextual_vars_dict[var]
 
 	# Get current priors parameters (normal-inverse-gamma)
 	mean = parameters['coef_mean']

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ scipy==1.8.0
 six==1.16.0
 termcolor==1.1.0
 tqdm==4.64.0
+xlsxwriter


### PR DESCRIPTION
Some Major Changes:
---
- Add multi-policy-simulation running in sequence.
- Now multiple policies can be configured in the same file before runnning the simulation.
- Each policy has its own simulation csv files and evaluation csv files under given output path.
- Allow reward and contexts shared between multiple policies: 
   - The policy which has both positive `is_unique_reward` and `is_unique_contexts` indicators has the highest priority in simulation running sequence. 
   - The policy which has positive `is_unique_reward` indicator has higher priority in simulation running sequence than the policy which has positive `is_unique_contexts` indicator.
- Current pull request no longer supports using the existing simulation csv file for evaluation purpose. I.e. `checkpoint_path` is not available for this pull request.
